### PR TITLE
Added a primaryKey option

### DIFF
--- a/src/connector.js
+++ b/src/connector.js
@@ -48,6 +48,7 @@ var Connector = function( options ) {
 	this._tableManager = new TableManager( this._connection );
 	this._defaultTable = options.defaultTable || 'deepstream_records';
 	this._splitChar = options.splitChar || null;
+	this._primaryKey = options.primaryKey || PRIMARY_KEY;
 };
 
 util.inherits( Connector, events.EventEmitter );
@@ -71,7 +72,7 @@ Connector.prototype.set = function( key, value, callback ) {
 	if( this._tableManager.hasTable( params.table ) ) {
 		insert();
 	} else {
-		this._tableManager.createTable( params.table, insert );
+		this._tableManager.createTable( params.table, this._primaryKey, insert );
 	}
 };
 
@@ -91,10 +92,10 @@ Connector.prototype.get = function( key, callback ) {
 	if( this._tableManager.hasTable( params.table ) ) {
 		rethinkdb.table( params.table ).get( params.id ).run( this._connection.get(), function( error, entry ){
 			if( entry ) {
-				delete entry[ PRIMARY_KEY ];
+				delete entry[ this._primaryKey ];
 			}
 			callback( error, entry );
-		});
+		}.bind(this));
 	} else {
 		callback( null, null );
 	}
@@ -169,7 +170,7 @@ Connector.prototype._getParams = function( key ) {
  * @returns {void}
  */
 Connector.prototype._insert = function( params, value, callback ) {
-	value[ PRIMARY_KEY ] = params.id;
+	value[ this._primaryKey ] = params.id;
 
 	rethinkdb
 		.table( params.table )

--- a/src/table-manager.js
+++ b/src/table-manager.js
@@ -1,6 +1,5 @@
 var EventEmitter = require( 'events' ).EventEmitter,
-	rethinkdb = require( 'rethinkdb' ),
-	PRIMARY_KEY = require( './primary-key' );
+	rethinkdb = require( 'rethinkdb' );
 
 var TableManager = function( connection ) {
 	this._connection = connection;
@@ -15,12 +14,12 @@ var TableManager = function( connection ) {
  * @private
  * @returns {void}
  */
-TableManager.prototype.createTable = function( table, callback ) {
+TableManager.prototype.createTable = function( table, primary_key, callback ) {
 	this._eventEmitter.once( table, callback );
 
 	if( this._eventEmitter.listeners( table ).length === 1 ) {
 		rethinkdb
-			.tableCreate( table, { primaryKey: PRIMARY_KEY, durability: 'soft' } )
+			.tableCreate( table, { primaryKey: primary_key, durability: 'soft' } )
 			.run( this._connection.get(), this._onTableCreated.bind( this, table ) );
 	}
 };

--- a/test/cache-connectorSpec-primary-key.js
+++ b/test/cache-connectorSpec-primary-key.js
@@ -1,0 +1,84 @@
+/* global describe, expect, it, jasmine */
+var CacheConnector = require( '../src/connector' ),
+	EventEmitter = require( 'events' ).EventEmitter,
+	connectionParams = require( './connection-params' ),
+	MESSAGE_TIME = 20;
+
+describe( 'the message connector has the correct structure', function(){
+	var cacheConnector;
+	
+	it( 'throws an error if required connection parameters are missing', function(){
+		expect(function(){ new CacheConnector( 'gibberish' ); }).toThrow();
+	});
+	
+	it( 'creates the cacheConnector', function( done ){
+		cacheConnector = new CacheConnector({ host: connectionParams.host, port: connectionParams.port, primaryKey: 'own-primary-key' });
+		expect( cacheConnector.isReady ).toBe( false );
+		cacheConnector.on( 'ready', done );
+		cacheConnector.on( 'error', function( error ){
+			console.log( error );
+		});
+	});
+	
+	it( 'implements the cache/storage connector interface', function() {
+	    expect( typeof cacheConnector.name ).toBe( 'string' );
+	    expect( typeof cacheConnector.version ).toBe( 'string' );
+	    expect( typeof cacheConnector.get ).toBe( 'function' );
+	    expect( typeof cacheConnector.set ).toBe( 'function' );
+	    expect( typeof cacheConnector.delete ).toBe( 'function' );
+	    expect( cacheConnector instanceof EventEmitter ).toBe( true );
+	});
+	
+	it( 'retrieves a non existing value', function( done ){
+		cacheConnector.get( 'someValue', function( error, value ){
+			expect( error ).toBe( null );
+			expect( value ).toBe( null );
+			done();
+		});
+	});
+	
+	it( 'sets a value', function( done ){
+		cacheConnector.set( 'someValue', { firstname: 'Wolfram' }, function( error ){
+			expect( error ).toBe( null );
+			done();
+		});
+	});
+	
+	it( 'retrieves an existing value', function( done ){
+		cacheConnector.get( 'someValue', function( error, value ){
+			expect( error ).toBe( null );
+			expect( value ).toEqual( { firstname: 'Wolfram' } );
+			done();
+		});
+	});
+
+	it( 'updates an existing value', function( done ){
+		cacheConnector.set( 'someValue', { firstname: 'Egon' }, function( error ){
+			expect( error ).toBe( null );
+			done();
+		});
+	});
+
+	it( 'retrieves the updated value', function( done ){
+		cacheConnector.get( 'someValue', function( error, value ){
+			expect( error ).toBe( null );
+			expect( value ).toEqual( { firstname: 'Egon' } );
+			done();
+		});
+	});
+	
+	it( 'deletes a value', function( done ){
+		cacheConnector.delete( 'someValue', function( error ){
+			expect( error ).toBe( null );
+			done();
+		});
+	});
+	
+	it( 'Can\'t retrieve a deleted value', function( done ){
+		cacheConnector.get( 'someValue', function( error, value ){
+			expect( error ).toBe( null );
+			expect( value ).toBe( null );
+			done();
+		});
+	});
+});


### PR DESCRIPTION
This way the user can choose which primary key the RethinkDB connection should use when creating/fetching documents and tables.